### PR TITLE
chore: update npm-run-all to npm-run-all2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "glob": "^7.1.2",
     "jsondiffpatch": "^0.1.4",
     "mocha": "^5.0.0",
-    "npm-run-all": "^4.1.2",
+    "npm-run-all2": "^6.1.1",
     "xsd-schema-validator": "^0.6.0"
   }
 }


### PR DESCRIPTION
This PR aims to replace `npm-run-all` which is no longer maintained (https://github.com/mysticatea/npm-run-all - last release November 2018).
The replacement `npm-run-all2` can be used as a replacement that is still actively maintained (https://github.com/bcomnes/npm-run-all2 - last release October 2023)


> npm-run-all2 why?
> 
> A maintenance fork of npm-run-all. npm-run-all2 is a fork of npm-run-all with dependabot updates, release automation enabled and some troublesome babel stuff removed to further reduce maintenance burden. Hopefully this labor can upstream some day when mysticatea returns, but until then, welcome aboard!
> 

Please note that I created this PR semi-automatically across all applicable projects in https://github.com/camunda and https://github.com/camunda-community-hub

Feel free to ping me if you find any issue with it or simply ignore it.